### PR TITLE
[R+M] Create Initial Mirrors Solution and Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,40 @@
+#Autosave files
+*~
+
+#build
+[Oo]bj/
+[Bb]in/
+packages/
+TestResults/
+
+# globs
+Makefile.in
+*.DS_Store
+*.sln.cache
+*.suo
+*.cache
+*.pidb
+*.userprefs
+*.usertasks
+config.log
+config.make
+config.status
+aclocal.m4
+install-sh
+autom4te.cache/
+*.user
+*.tar.gz
+tarballs/
+test-results/
+Thumbs.db
+
+#Mac bundle stuff
+*.dmg
+*.app
+
+#resharper
+*_Resharper.*
+*.Resharper
+
+#dotCover
+*.dotCover

--- a/DuPontMirrors.sln
+++ b/DuPontMirrors.sln
@@ -1,0 +1,17 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DuPontMirrors", "DuPontMirrors\DuPontMirrors.csproj", "{90E99457-F32F-4DF9-B723-C7B8A919D395}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x86 = Debug|x86
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{90E99457-F32F-4DF9-B723-C7B8A919D395}.Debug|x86.ActiveCfg = Debug|x86
+		{90E99457-F32F-4DF9-B723-C7B8A919D395}.Debug|x86.Build.0 = Debug|x86
+		{90E99457-F32F-4DF9-B723-C7B8A919D395}.Release|x86.ActiveCfg = Release|x86
+		{90E99457-F32F-4DF9-B723-C7B8A919D395}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+EndGlobal

--- a/DuPontMirrors/Building.cs
+++ b/DuPontMirrors/Building.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace DuPontMirrors
+{
+	public class Building
+	{
+		Room[,] rooms;
+		public int Height { get; private set; }
+		public int Width { get; private set; }
+		public Vector InitialVector { get; private set; }
+
+		public Building (string path) {
+			string line;
+			StreamReader file = new System.IO.StreamReader(path);
+
+			int phase = 0;
+			while((line = file.ReadLine()) != null)
+			{
+				if (line == "-1") {
+					phase++;
+					continue;
+				}
+
+				if (phase == 0) {
+					SetBuildingSize (line);
+				}
+
+				if (phase == 1) {
+					CreateRoom (line);
+				}
+
+				if (phase == 2) {
+					SetInitialVector (line);
+				}
+			}
+
+			file.Close();
+		}
+
+		private void SetBuildingSize (string line) {
+			string [] coordinates = line.Split (',');
+			Width = Convert.ToInt32 (coordinates [0]);
+			Height = Convert.ToInt32 (coordinates [1]);
+			rooms = new Room[Width, Height]; // TODO: This needs to have better memory management
+		}
+
+		private void CreateRoom(string line) {
+			string [] coordinates = line.Split(',');
+			int x = Convert.ToInt32 (coordinates [0]);
+			int y = ParseCoordinate(coordinates[1]);
+			string mirrorType = ParseCoordinateMetaData(coordinates[1], "[L|R]{1,2}");
+			AddRoom (x, y, mirrorType);
+		}
+
+		private void SetInitialVector (string line) {
+			string[] coordinates = line.Split (',');
+			int x = Convert.ToInt32 (coordinates [0]);
+			int y = ParseCoordinate (coordinates [1]);
+			CardinalDirection direction = GetCardinalDirection(x, y, ParseCoordinateMetaData (coordinates [1], "[V|H]"));
+
+			InitialVector = new Vector (x, y, direction);
+		}
+
+		public static int ParseCoordinate(string coordinate) {
+			return Convert.ToInt32 (Regex.Match (coordinate, @"\d+").Value);
+		}
+
+		public static string ParseCoordinateMetaData(string coordinate, string pattern) {
+			return Regex.Match (coordinate.ToUpper (), pattern).Value;
+		}
+
+		public static CardinalDirection GetCardinalDirection(int x, int y, string stringlyDirection) {
+			CardinalDirection direction;
+
+			if (stringlyDirection == "V") {
+				direction = y == 0 ? CardinalDirection.North : CardinalDirection.South;
+			} else if (stringlyDirection == "H") {
+				direction = x == 0 ? CardinalDirection.East : CardinalDirection.West;
+			} else {
+				throw new InvalidDataException ("Invalid initial vector");
+			}
+
+			return direction;
+		}
+			
+		public Building (int width, int height)
+		{
+			this.Width = width;
+			this.Height = height;
+			rooms = new Room[width, height];
+		}
+
+		public static RoomType ConvertStringToRoomType (string type) {
+			switch (type) {
+				case "L":
+					return RoomType.TwoWayMirrorLeansWest;
+				case "R":
+					return RoomType.TwoWayMirrorLeansEast;
+				case "RL":
+					return RoomType.OneWayMirrorLeansEastReflectsNorth;
+				case "RR":
+					return RoomType.OneWayMirrorLeansEastReflectsSouth;
+				case "LR":
+					return RoomType.OneWayMirrorLeansWestReflectsNorth;
+				case "LL":
+					return RoomType.OneWayMirrorLeansWestReflectsSouth;
+				default:
+					return RoomType.None;
+			}
+		}
+
+		public void AddRoom (int x, int y, string mirrorType)
+		{
+			RoomType type = ConvertStringToRoomType (mirrorType);
+			rooms[x, y] = new Room (type, x, y);
+		}
+
+		public void AddRoom (int x, int y, RoomType type)
+		{
+			rooms [x, y] = new Room (type, x, y);
+		}
+
+		public bool Contains(LightBeam beam)
+		{
+			return beam.CurrentVector.X >= 0 && beam.CurrentVector.Y >= 0 && beam.CurrentVector.X < this.Width && beam.CurrentVector.Y < this.Height;
+		}
+
+		public Room GetCurrentRoom(Vector vector)
+		{
+			return this.rooms[vector.X, vector.Y];
+		}
+
+		public void MarkRoomAsVisited(Room room, Vector vector)
+		{
+			room.Visit (vector.Direction);
+		}
+
+		public bool WasVisited(LightBeam beam)
+		{
+			Room room = GetCurrentRoom (beam.CurrentVector);
+			return room == null ? false : room.WasVisited (beam.CurrentVector.Direction);
+		}
+
+		public bool HasReflection(LightBeam beam)
+		{
+			Room room = GetCurrentRoom (beam.CurrentVector);
+			return room != null && room.HasReflection (beam.CurrentVector.Direction);
+		}
+
+		public CardinalDirection GetUpdatedDirection(Room room, Vector vector)
+		{
+			return room.GetReflectedDirection(vector.Direction);
+		}
+
+		public void Reflect(LightBeam beam)
+		{
+			Room room = this.GetCurrentRoom (beam.CurrentVector);
+			Vector vector = beam.CurrentVector;
+			beam.Bend (this.GetUpdatedDirection (room, beam.CurrentVector));
+			MarkRoomAsVisited (room, vector);
+		}
+	}
+}

--- a/DuPontMirrors/CardinalDirection.cs
+++ b/DuPontMirrors/CardinalDirection.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace DuPontMirrors
+{
+	public enum CardinalDirection
+	{ 
+		North = 0,
+		South = 1,
+		East = 2,
+		West = 3 
+	}
+}
+

--- a/DuPontMirrors/DuPontMirrors.csproj
+++ b/DuPontMirrors/DuPontMirrors.csproj
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProjectGuid>{90E99457-F32F-4DF9-B723-C7B8A919D395}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>DuPontMirrors</RootNamespace>
+    <AssemblyName>DuPontMirrors</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Externalconsole>true</Externalconsole>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Externalconsole>true</Externalconsole>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Building.cs" />
+    <Compile Include="LightBeam.cs" />
+    <Compile Include="Vector.cs" />
+    <Compile Include="CardinalDirection.cs" />
+    <Compile Include="Room.cs" />
+    <Compile Include="RoomType.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/DuPontMirrors/DuPontMirrors.sln
+++ b/DuPontMirrors/DuPontMirrors.sln
@@ -1,0 +1,17 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DuPontMirrors", "DuPontMirrors.csproj", "{90E99457-F32F-4DF9-B723-C7B8A919D395}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x86 = Debug|x86
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{90E99457-F32F-4DF9-B723-C7B8A919D395}.Debug|x86.ActiveCfg = Debug|x86
+		{90E99457-F32F-4DF9-B723-C7B8A919D395}.Debug|x86.Build.0 = Debug|x86
+		{90E99457-F32F-4DF9-B723-C7B8A919D395}.Release|x86.ActiveCfg = Release|x86
+		{90E99457-F32F-4DF9-B723-C7B8A919D395}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+EndGlobal

--- a/DuPontMirrors/LightBeam.cs
+++ b/DuPontMirrors/LightBeam.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace DuPontMirrors
+{
+	public class LightBeam
+	{
+		public Vector InitialVector { get; }
+		public Vector CurrentVector { get; private set; }
+		public List<Vector> Trail { get; }
+
+		public LightBeam (Vector initial)
+		{
+			this.InitialVector = new Vector (initial.X, initial.Y, initial.Direction);
+			this.CurrentVector = new Vector (initial.X, initial.Y, initial.Direction);
+			this.Trail = new List<Vector> ();
+			this.Trail.Add (this.CurrentVector);
+		}
+
+		public void Traverse()
+		{
+			this.CurrentVector = Vector.Increment(this.CurrentVector);
+			this.Trail.Add (this.CurrentVector);
+		}
+
+		public void Bend(CardinalDirection direction)
+		{
+			this.CurrentVector = Vector.Redirect(this.CurrentVector, direction);
+			this.Trail.Add (this.CurrentVector);
+			this.Traverse ();
+		}
+	}
+}
+

--- a/DuPontMirrors/Program.cs
+++ b/DuPontMirrors/Program.cs
@@ -7,8 +7,7 @@ namespace DuPontMirrors
 	{
 		public static void Main (string[] args)
 		{
-			// string path = PromptUserForFile();
-			string path = "/Users/mjbarsema/Documents/Work Related/DuPont/test1.txt"; // TODO: Remove this for prompt.
+			string path = PromptUserForFile();
 			Building building = new Building (path);
 
 			LightBeam beam = new LightBeam (building.InitialVector);

--- a/DuPontMirrors/Program.cs
+++ b/DuPontMirrors/Program.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.IO;
+
+namespace DuPontMirrors
+{
+	class MainClass
+	{
+		public static void Main (string[] args)
+		{
+			// string path = PromptUserForFile();
+			string path = "/Users/mjbarsema/Documents/Work Related/DuPont/test1.txt"; // TODO: Remove this for prompt.
+			Building building = new Building (path);
+
+			LightBeam beam = new LightBeam (building.InitialVector);
+			while (building.Contains(beam) && !building.WasVisited(beam)) {
+				if (building.HasReflection (beam)) {
+					building.Reflect (beam);
+				} else {
+					beam.Traverse ();
+				}
+			}
+
+			PrintResults (building, beam);
+
+			Console.WriteLine ("Press any key to continue");
+			Console.ReadKey ();
+		}
+
+		public static string PromptUserForFile()
+		{
+			Console.WriteLine ("Enter path to file:");
+			string file = Console.ReadLine ();
+
+			while (!File.Exists (file)) {
+				Console.WriteLine ("File does not exist");
+				Console.WriteLine ("Enter path to file:");
+				file = Console.ReadLine ();
+			}
+
+			return file;
+		}
+
+		public static void PrintResults(Building building, LightBeam beam)
+		{
+			Console.WriteLine ("Board dimensions: {0} (w) x {1} (h)", building.Width, building.Height);
+			Console.WriteLine (
+				"Initial starting position {0},{1}\t{2}",
+				building.InitialVector.X,
+				building.InitialVector.Y,
+				building.InitialVector.Direction == CardinalDirection.North || building.InitialVector.Direction == CardinalDirection.South ? "V" : "H"
+			);
+
+			if (!building.Contains (beam)) {
+				Vector final = beam.Trail [beam.Trail.Count - 2];
+
+				Console.WriteLine (
+					"Exit position {0},{1}\t{2}",
+					final.X,
+					final.Y,
+					final.Direction == CardinalDirection.North || final.Direction == CardinalDirection.South ? "V" : "H"
+				);
+			} else {
+				Console.WriteLine ("Beam entered a loop and never exited");
+				Console.WriteLine ("Last position before loop detected:");
+
+				Vector final = beam.Trail [beam.Trail.Count - 2];
+
+				Console.WriteLine (
+					"Exit position {0},{1}\t{2}",
+					final.X,
+					final.Y,
+					final.Direction == CardinalDirection.North || final.Direction == CardinalDirection.South ? "V" : "H"
+				);
+			}
+
+			Console.WriteLine ("Beam trail:");
+			foreach (Vector v in beam.Trail) {
+				if (v.X >= 0 && v.Y >= 0 && v.X < building.Width && v.Y < building.Height) {
+					Console.WriteLine (string.Format ("{0},{1}\t Heading {2}", v.X, v.Y, v.Direction));
+				}
+			}
+		}
+	}
+}

--- a/DuPontMirrors/Properties/AssemblyInfo.cs
+++ b/DuPontMirrors/Properties/AssemblyInfo.cs
@@ -1,0 +1,27 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes.
+// Change them to the values specific to your project.
+
+[assembly: AssemblyTitle ("DuPontMirrors")]
+[assembly: AssemblyDescription ("")]
+[assembly: AssemblyConfiguration ("")]
+[assembly: AssemblyCompany ("")]
+[assembly: AssemblyProduct ("")]
+[assembly: AssemblyCopyright ("mjbarsema")]
+[assembly: AssemblyTrademark ("")]
+[assembly: AssemblyCulture ("")]
+
+// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
+// The form "{Major}.{Minor}.*" will automatically update the build and revision,
+// and "{Major}.{Minor}.{Build}.*" will update just the revision.
+
+[assembly: AssemblyVersion ("1.0.*")]
+
+// The following attributes are used to specify the signing key for the assembly,
+// if desired. See the Mono documentation for more information about signing.
+
+//[assembly: AssemblyDelaySign(false)]
+//[assembly: AssemblyKeyFile("")]
+

--- a/DuPontMirrors/Room.cs
+++ b/DuPontMirrors/Room.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace DuPontMirrors
+{
+	public class Room
+	{
+		Dictionary<CardinalDirection, bool> isVisited;
+		Dictionary<CardinalDirection, bool> canReflect;
+		Dictionary<CardinalDirection, CardinalDirection> reflectedDirection;
+		RoomType roomType;
+		bool leansEast;
+		bool leansWest;
+
+		public Room (RoomType type, int startX, int startY)
+		{
+			roomType = type;
+			leansEast = false;
+			leansWest = false;
+
+			isVisited = new Dictionary<CardinalDirection, bool> ();
+			isVisited [CardinalDirection.North] = false;
+			isVisited [CardinalDirection.South] = false;
+			isVisited [CardinalDirection.East] = false;
+			isVisited [CardinalDirection.West] = false;
+
+			canReflect = new Dictionary<CardinalDirection, bool> ();
+			canReflect [CardinalDirection.North] = false;
+			canReflect [CardinalDirection.South] = false;
+			canReflect [CardinalDirection.East] = false;
+			canReflect [CardinalDirection.West] = false;
+
+			reflectedDirection = new Dictionary<CardinalDirection, CardinalDirection> ();
+
+			if (type == RoomType.TwoWayMirrorLeansEast || type == RoomType.OneWayMirrorLeansEastReflectsNorth || type == RoomType.OneWayMirrorLeansEastReflectsSouth) {
+				leansEast = true;
+			}
+
+			if (type == RoomType.TwoWayMirrorLeansWest || type == RoomType.OneWayMirrorLeansWestReflectsNorth || type == RoomType.OneWayMirrorLeansWestReflectsSouth) {
+				leansWest = true;
+			}
+
+			if (type == RoomType.TwoWayMirrorLeansEast || type == RoomType.TwoWayMirrorLeansWest) {
+				canReflect [CardinalDirection.North] = true;
+				canReflect [CardinalDirection.South] = true;
+				canReflect [CardinalDirection.East] = true;
+				canReflect [CardinalDirection.West] = true;
+			} else {
+				if (roomType == RoomType.OneWayMirrorLeansEastReflectsSouth || roomType == RoomType.OneWayMirrorLeansWestReflectsSouth) {
+					canReflect [CardinalDirection.North] = true;
+				}
+
+				if (roomType == RoomType.OneWayMirrorLeansEastReflectsNorth || roomType == RoomType.OneWayMirrorLeansWestReflectsNorth) {
+					canReflect [CardinalDirection.South] = true;
+				}
+
+				if (roomType == RoomType.OneWayMirrorLeansWestReflectsNorth || roomType == RoomType.OneWayMirrorLeansEastReflectsSouth) {
+					canReflect [CardinalDirection.East] = true;
+				}
+
+				if (roomType == RoomType.OneWayMirrorLeansEastReflectsNorth || roomType == RoomType.OneWayMirrorLeansWestReflectsSouth) {
+					canReflect [CardinalDirection.West] = true;
+				}
+			}
+
+			if (leansEast) {
+				reflectedDirection [CardinalDirection.North] = CardinalDirection.East;
+				reflectedDirection [CardinalDirection.South] = CardinalDirection.West;
+				reflectedDirection [CardinalDirection.East] = CardinalDirection.North;
+				reflectedDirection [CardinalDirection.West] = CardinalDirection.South;
+			} else if (leansWest) {
+				reflectedDirection [CardinalDirection.North] = CardinalDirection.West;
+				reflectedDirection [CardinalDirection.South] = CardinalDirection.East;
+				reflectedDirection [CardinalDirection.East] = CardinalDirection.South;
+				reflectedDirection [CardinalDirection.West] = CardinalDirection.North;
+			}
+		}
+
+		public void Visit(CardinalDirection direction)
+		{
+			isVisited [direction] = true;
+		}
+
+		public bool WasVisited (CardinalDirection direction)
+		{
+			return isVisited [direction];
+		}
+
+		public bool HasReflection (CardinalDirection direction)
+		{
+			return canReflect [direction];
+		}
+
+		public CardinalDirection GetReflectedDirection (CardinalDirection direction)
+		{
+			return reflectedDirection [direction];
+		}
+	}
+}

--- a/DuPontMirrors/RoomType.cs
+++ b/DuPontMirrors/RoomType.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace DuPontMirrors
+{
+	// TODO: Check nomenclature here
+	public enum RoomType
+	{
+		None = 0,
+		TwoWayMirrorLeansWest = 1,  // "L"
+		TwoWayMirrorLeansEast = 2, // "R"
+		OneWayMirrorLeansEastReflectsNorth = 3, // "RL"
+		OneWayMirrorLeansEastReflectsSouth = 4, // "RR"
+		OneWayMirrorLeansWestReflectsNorth = 5, // "LR"
+		OneWayMirrorLeansWestReflectsSouth = 6 // "LL"
+	}
+}
+

--- a/DuPontMirrors/Vector.cs
+++ b/DuPontMirrors/Vector.cs
@@ -1,0 +1,42 @@
+﻿using System;
+
+namespace DuPontMirrors
+{
+	public class Vector
+	{
+		public int X { get; }
+		public int Y { get; }
+		public int Length { get; }
+		public CardinalDirection Direction { get; }
+				
+		public Vector (int x, int y, CardinalDirection direction, int length = 1)
+		{
+			this.X = x;
+			this.Y = y;
+			this.Direction = direction;
+			this.Length = length;
+		}
+
+		public static Vector Increment (Vector vector)
+		{
+			switch (vector.Direction) {
+				case CardinalDirection.North:
+					return new Vector(vector.X, vector.Y + vector.Length, CardinalDirection.North);
+				case CardinalDirection.South:
+					return new Vector(vector.X, vector.Y - vector.Length, CardinalDirection.South);
+				case CardinalDirection.East:
+					return new Vector(vector.X + vector.Length, vector.Y, CardinalDirection.East);
+				case CardinalDirection.West:
+					return new Vector(vector.X - vector.Length, vector.Y, CardinalDirection.West);
+			}
+
+			return vector;
+		}
+
+		public static Vector Redirect (Vector vector, CardinalDirection direction) 
+		{
+			return new Vector(vector.X, vector.Y, direction); 
+		}
+	}
+}
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# dupont-mirrors
+Test Solution for DuPont Interview


### PR DESCRIPTION
## Changes
Creates the initial source code for the DuPont Mirrors project. 

The goal was to create a a way to parse an input file and generate output such that given a properly formatted file, the exit vector would be calculated.  More information will eventually be in the README.

### Notes

There are a couple of problems with this code right now.

1. `Building.cs` should be refactored to use better memory management.
2. `Room.cs` should be refactored to be cleaner. This code (at the moment) is a bit clunky. Changing it to using class inheritance based on mirror type can remove a good chunk of code.
3. `README.md` needs to be updated to reflect the nature of the project along with other detailed notes on the project (including *these* notes on action items).
4. Unit testing needs to be fully fleshed out, only barebones unit tests have been run at this point and not really in any official capacity.
5. An actual executable and all of the project files should be added.